### PR TITLE
Fix home navigation and binding cleanup

### DIFF
--- a/app/src/main/java/com/pinup/barapp/ui/fragments/BlankFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/BlankFragment.kt
@@ -12,13 +12,14 @@ import com.pinup.barapp.ui.MainActivity
 
 class BlankFragment : Fragment() {
 
-    private lateinit var binding: FragmentBlankBinding
+    private var _binding: FragmentBlankBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentBlankBinding.inflate(inflater, container, false)
+        _binding = FragmentBlankBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -36,6 +37,7 @@ class BlankFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        _binding = null
     }
 
     private fun cardsListener() {

--- a/app/src/main/java/com/pinup/barapp/ui/fragments/EventFragmentDetail.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/EventFragmentDetail.kt
@@ -16,14 +16,15 @@ import com.pinup.barapp.domain.models.Event
 
 class EventFragmentDetail : Fragment() {
 
-    private lateinit var binding: FragmentEventDetailBinding
+    private var _binding: FragmentEventDetailBinding? = null
+    private val binding get() = _binding!!
     private val args by navArgs<EventFragmentDetailArgs>()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentEventDetailBinding.inflate(inflater,container,false)
+        _binding = FragmentEventDetailBinding.inflate(inflater,container,false)
         return binding.root
     }
 
@@ -89,5 +90,10 @@ class EventFragmentDetail : Fragment() {
         binding.btnBack.setOnClickListener {
             findNavController().popBackStack()
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/pinup/barapp/ui/fragments/HomePinupFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/HomePinupFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.setupWithNavController
 import com.pinup.barapp.R
 import com.pinup.barapp.databinding.FragmentPinupHomeBinding
@@ -15,12 +16,13 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class HomePinupFragment : Fragment() {
 
-    private lateinit var binding: FragmentPinupHomeBinding
+    private var _binding: FragmentPinupHomeBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentPinupHomeBinding.inflate(inflater, container, false)
+        _binding = FragmentPinupHomeBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -33,6 +35,16 @@ class HomePinupFragment : Fragment() {
         binding.bottomNavigation.setupWithNavController(navController)
         binding.bottomNavigation.selectedItemId = R.id.blankFragment
 
+        binding.bottomNavigation.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.blankFragment -> {
+                    navController.popBackStack(R.id.blankFragment, false)
+                    true
+                }
+                else -> NavigationUI.onNavDestinationSelected(item, navController)
+            }
+        }
+
         navController.addOnDestinationChangedListener { _, destination, _ ->
             when (destination.id) {
                 R.id.blankFragment,
@@ -44,5 +56,10 @@ class HomePinupFragment : Fragment() {
         }
 
 
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/pinup/barapp/ui/fragments/ScheduleFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/ScheduleFragment.kt
@@ -67,5 +67,10 @@ class ScheduleFragment : Fragment(R.layout.fragment_schedule) {
 
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
 
 }

--- a/app/src/main/java/com/pinup/barapp/ui/fragments/WelcomePinupFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/WelcomePinupFragment.kt
@@ -16,12 +16,13 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class WelcomePinupFragment : Fragment() {
 
-    private lateinit var binding: FragmentWelcomePinupBinding
+    private var _binding: FragmentWelcomePinupBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentWelcomePinupBinding.inflate(inflater, container, false)
+        _binding = FragmentWelcomePinupBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -33,5 +34,10 @@ class WelcomePinupFragment : Fragment() {
             parentFragmentManager.launchSportBarFragmentWithoutBackstack(HomePinupFragment())
         }
 
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }


### PR DESCRIPTION
## Summary
- reset bottom navigation stack when tapping Home
- prevent fragment view-binding leaks

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a71ccb7fc832ab1863426c0efffff